### PR TITLE
Fix prayer duration input treating values as hours instead of minutes…

### DIFF
--- a/salatak/components/PrayersInput.vue
+++ b/salatak/components/PrayersInput.vue
@@ -5,6 +5,18 @@ const prayersStore = usePrayersStore()
 const { prayers } = storeToRefs(prayersStore)
 const { setPrayActive, setPrayDuration, setPrayRemainder } = prayersStore
 
+// Handle duration input with validation
+const handleDurationInput = (prayer: any, event: any) => {
+  const value = event.target.value
+  setPrayDuration(prayer, value)
+  
+  // Update the input value to reflect any corrections made by the store
+  const updatedPrayer = prayersStore.getPray(prayer.name)
+  if (updatedPrayer && updatedPrayer.duration !== Number(value)) {
+    event.target.value = updatedPrayer.duration
+  }
+}
+
 </script>
 
 
@@ -19,7 +31,7 @@ const { setPrayActive, setPrayDuration, setPrayRemainder } = prayersStore
             <th>
             </th>
             <th>{{ $t("Prayer") }}</th>
-            <th>{{ $t("Duration") }}</th>
+            <th>{{ $t("Duration") }} ({{ $t("minutes") }})</th>
           </tr>
         </thead>
         <tbody>
@@ -34,8 +46,17 @@ const { setPrayActive, setPrayDuration, setPrayRemainder } = prayersStore
               {{ $t(prayer.name) }}
             </td>
             <td>
-              <input @input="(e: any) => { setPrayDuration(prayer, e.target.value) }" type="number" class="input w-20"
-                :value="prayer.duration">
+              <input 
+                @input="(e: any) => handleDurationInput(prayer, e)" 
+                type="number" 
+                class="input w-20"
+                :value="prayer.duration"
+                min="1"
+                max="180"
+                step="1"
+                :placeholder="$t('minutes')"
+                title="Duration in minutes (1-180)"
+              >
             </td>
           </tr>
         </tbody>

--- a/salatak/i18n.config.ts
+++ b/salatak/i18n.config.ts
@@ -51,6 +51,7 @@ export default defineI18nConfig(() => ({
       "Preview": "Preview",
       "schedule_prayers": "Schedule your prayers on any calendar now!",
       "text_copied_to_clipboard": "Url Copied",
+      "minutes": "minutes",
     },
     ar: {
       "welcome": "اهلا",
@@ -100,7 +101,8 @@ export default defineI18nConfig(() => ({
       "Preview Calendar": "معاينة التقويم",
       "Download Calendar": "تحميل التقويم",
       "Preview": "معاينة",
-      "text_copied_to_clipboard": "تم نسخ العنوان بنجاح"
+      "text_copied_to_clipboard": "تم نسخ العنوان بنجاح",
+      "minutes": "دقائق",
     }
   }
 }))

--- a/salatak/stores/prayersStore.ts
+++ b/salatak/stores/prayersStore.ts
@@ -109,12 +109,44 @@ export const usePrayersStore = defineStore('prayers', {
     setPrayDuration(pray: any, duration: any) {
       let p = this.getPray(pray.name)
       if (!p) return
-      p.duration = duration
+      
+      // Convert to number and validate
+      const numDuration = Number(duration)
+      if (isNaN(numDuration) || numDuration < 0) {
+        console.warn(`Invalid duration value: ${duration}. Using default value of 10.`)
+        p.duration = 10
+        return
+      }
+      
+      // Ensure reasonable limits (max 180 minutes = 3 hours)
+      if (numDuration > 180) {
+        console.warn(`Duration too large: ${numDuration}. Setting to maximum of 180 minutes.`)
+        p.duration = 180
+        return
+      }
+      
+      p.duration = numDuration
     },
     setPrayRemainder(pray: any, duration: any) {
       let p = this.getPray(pray.name)
       if (!p) return
-      p.remainder = duration
+      
+      // Convert to number and validate
+      const numRemainder = Number(duration)
+      if (isNaN(numRemainder) || numRemainder < 0) {
+        console.warn(`Invalid remainder value: ${duration}. Using default value of 15.`)
+        p.remainder = 15
+        return
+      }
+      
+      // Ensure reasonable limits (max 60 minutes for reminder)
+      if (numRemainder > 60) {
+        console.warn(`Remainder too large: ${numRemainder}. Setting to maximum of 60 minutes.`)
+        p.remainder = 60
+        return
+      }
+      
+      p.remainder = numRemainder
     },
     setStartDate(date: any) {
       const d = new Date(date);
@@ -219,7 +251,7 @@ export const usePrayersStore = defineStore('prayers', {
             if (!prayerConfig || !prayerConfig.checked) return
             
             let dayName = day.date.gregorian.weekday.en
-            let bufferTime = dayName == "Friday" && pray.name == "Dhuhr" ? JUMMAH_TIME_BUFFER : prayerConfig.duration
+            let bufferTime = dayName == "Friday" && pray.name == "Dhuhr" ? JUMMAH_TIME_BUFFER : Number(prayerConfig.duration)
             let prayName = dayName == "Friday" && pray.name == "Dhuhr" ? "Jummuah" : pray.name
             let prayDateStart = new Date(`${day.date.readable} ${pray.date}`)
             let prayDateEnd = new Date(prayDateStart)


### PR DESCRIPTION
… - Fixed bug where prayer duration input was storing string values instead of numbers - Added proper number conversion and validation in setPrayDuration() and setPrayRemainder() - Added input validation with min/max limits (1-180 minutes for duration, 1-60 for remainder) - Enhanced UI with clear labeling showing duration is in minutes - Added proper input attributes (min, max, step, placeholder, title) for better UX - Ensured Number() conversion in mapTimingsToEvents to prevent string arithmetic - Added Arabic translation for minutes text - This resolves the issue where entering 30 for prayer duration would create 30-hour events instead of 30-minute events